### PR TITLE
Make Lexer.cpp compile under Linux and Windows

### DIFF
--- a/Lexer.cpp
+++ b/Lexer.cpp
@@ -620,7 +620,11 @@ static const flex_int16_t yy_rule_linenum[31] =
  * The user has a chance to override it with an option.
  */
 /* %if-c-only */
+#if defined _WIN32 || defined _WIN64
+#include <io.h>
+#elif __linux__
 #include <unistd.h>
+#endif
 /* %endif */
 /* %if-c++-only */
 /* %endif */

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # ExpressionParser
 A parser for expressions and assignments based on Flex and Bison
+
+# Compilation under Windows and Linux
+Depending on how the file *Lexer.cpp* was generated, it can define an include for either *unistd.h* or *io.h*.
+The first file only exists on Linux, the latter only on Windows.
+To allow compilation on both, Linux and Windows, the file *Lexer.cpp* has to be manually adapted after generation, and either
+
+```
+#include <unistd.h>
+```
+
+or
+
+```
+#include <io.h>
+```
+
+should be replaced with
+
+```
+#if defined _WIN32 || defined _WIN64
+#include <io.h>
+#elif __linux__
+#include <unistd.h>
+#endif
+```


### PR DESCRIPTION
- Modification of `Lexer.cpp` to make it compile under both, Linux and Windows.
- Includes updating the README file what changes need to be made after re-generating `Lexer.cpp`.